### PR TITLE
feat: autogen tool calling and prompt context

### DIFF
--- a/models/agent.py
+++ b/models/agent.py
@@ -57,7 +57,7 @@ class Agent:
         else:
             self.id = id
 
-        self.name: str = cast(str, None)
+        self.name: str = ""
         self._client: OpenAIChatCompletionClient = cast(
             OpenAIChatCompletionClient, None
         )

--- a/models/configuration.py
+++ b/models/configuration.py
@@ -4,11 +4,13 @@ from typing import Optional, Dict, Any, cast, List
 import uuid
 from pydantic import BaseModel, Field
 
+
 class ConfigurationData(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str
     agents: List[Dict[str, Any]]
     settings: Dict[str, Any] = {}
+
 
 class Configuration:
     def __init__(self, db: TinyDB) -> None:
@@ -54,8 +56,11 @@ class Configuration:
         Delete a configuration record by its name (case-insensitive).
         """
         table = self._db.table(self._table_name)
-        to_remove = [document.doc_id for document in table.all()
-                     if document.get("name", "").lower() == name.lower()]
+        to_remove = [
+            document.doc_id
+            for document in table.all()
+            if document.get("name", "").lower() == name.lower()
+        ]
         if to_remove:
             table.remove(doc_ids=to_remove)
             logger.info(f"Configuration '{name}' deleted successfully.")

--- a/models/context.py
+++ b/models/context.py
@@ -1,0 +1,123 @@
+from pydantic import BaseModel, Field
+from enum import Enum
+from typing import Annotated, Union, Literal
+# from typing import Optional
+
+
+class ObservationType(str, Enum):
+    RESOURCE = "Resource"
+    AGENT = "Agent"
+    OBSTACLE = "Obstacle"
+    OTHER = "Other"
+
+
+class _BaseObs(BaseModel):
+    location: str
+    distance: int
+    id: str
+
+
+class ResourceObservation(_BaseObs):
+    type: Literal[ObservationType.RESOURCE]
+    energy_yield: int
+    available: bool
+
+    def __str__(self) -> str:
+        return (
+            f"{self.type.value} with ID {self.id} "
+            f"at location {self.location} with a distance of {self.distance}. "
+            f"Its energy yield is {self.energy_yield} and it is currently "
+            f"{'available' if self.available else 'unavailable'}. "
+        )
+
+
+class AgentObservation(_BaseObs):
+    type: Literal[ObservationType.AGENT]
+    name: str
+    relationship_status: str
+
+    def __str__(self) -> str:
+        return (
+            f"{self.type.value} with ID {self.id} and name {self.name} "
+            f"at location {self.location} with a distance of {self.distance}. "
+            f"Your relationship status to this person is {self.relationship_status}. "
+        )
+
+
+class ObstacleObservation(_BaseObs):
+    type: Literal[ObservationType.OBSTACLE]
+    # no extra fields
+
+    def __str__(self) -> str:
+        return (
+            f"{self.type.value} with ID {self.id} "
+            f"Location {self.location}, distance {self.distance}. "
+        )
+
+
+class OtherObservation(_BaseObs):
+    type: Literal[ObservationType.OTHER]
+    # no extra fields
+
+    def __str__(self) -> str:
+        return (
+            f"{self.type.value} with ID {self.id} "
+            f"Location {self.location}, distance {self.distance}. "
+        )
+
+
+Observation = Annotated[
+    Union[
+        ResourceObservation,
+        AgentObservation,
+        ObstacleObservation,
+        OtherObservation,
+    ],
+    Field(discriminator="type"),
+]
+
+
+class Message(BaseModel):
+    """A message from another agent."""
+
+    content: str
+    sender_id: str
+
+
+# TODO: consider if the following would make more sense to be part of their actual classes. In general it can be considered if the context classes can be combined with the actual ones, if the exist.
+class PlanContext(BaseModel):
+    """A plan for resource acquisition."""
+
+    id: str
+    owner: str
+    goal: str
+    participants: list[str]  # ids of agents
+    tasks: list[str] = []  # ids of tasks
+    total_payoff: int = 0
+
+    def __str__(self) -> str:
+        return (
+            f"Plan with ID: {self.id}, owner: {self.owner}, goal: {self.goal}, total expected payoff: {self.total_payoff}. "
+            f"This plan has the following participants: {', '.join(self.participants)}. "
+            f"This plan has the following tasks: {', '.join(self.tasks)}. "
+        )
+
+
+class TaskContext(BaseModel):
+    """A task for resource acquisition."""
+
+    id: str
+    plan_id: str
+    target: str | None = None
+    payoff: int = 0
+    # status: str = "PENDING"
+    worker: str | None = None
+
+    def __str__(self) -> str:
+        return (
+            f"Task with ID: {self.id}, target: {self.target}, payoff: {self.payoff}. "
+            f"This task is part of plan: {self.plan_id}. "
+            f"This task is assigned to agent: {self.worker}. "
+        )
+
+    # TODO: this probably needs improvement

--- a/models/conversation.py
+++ b/models/conversation.py
@@ -4,8 +4,17 @@ from typing import List, Dict, Optional
 from tinydb.queries import Query
 
 
+# TODO: instead of this custom implementation it might be worth it to consider using native autogen functionalities such as RoundRobinGroupChat
+# https://microsoft.github.io/autogen/stable/reference/python/autogen_agentchat.teams.html#autogen_agentchat.teams.RoundRobinGroupChat
+# when a conversation is initiated this temporarily creates a "team" and they chat
+# https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/teams.html#creating-a-team
+# Turns would be however be triggered by function calls and only each tick so maybe approach is slightly different
+
+
 class Conversation:
-    def __init__(self, db, simulation_id: str, agent_ids: List[str], initial_prompt: str = None):
+    def __init__(
+        self, db, simulation_id: str, agent_ids: List[str], initial_prompt: str = None
+    ):
         self.id = uuid.uuid4().hex
         self._db = db
         self.simulation_id = simulation_id
@@ -13,27 +22,31 @@ class Conversation:
         self.current_agent_index = 0
         self.status = "active"
         self.messages = []
-        
+
         if initial_prompt:
-            self.messages.append({
-                "sender_id": "system",
-                "content": initial_prompt,
-                "timestamp": str(datetime.now())
-            })
-    
+            self.messages.append(
+                {
+                    "sender_id": "system",
+                    "content": initial_prompt,
+                    "timestamp": str(datetime.now()),
+                }
+            )
+
     def save(self):
         """Save the conversation to the database"""
         table = self._db.table("agent_conversations")
-        table.insert({
-            "id": self.id,
-            "simulation_id": self.simulation_id,
-            "agent_ids": self.agent_ids,
-            "current_agent_index": self.current_agent_index,
-            "status": self.status,
-            "messages": self.messages
-        })
+        table.insert(
+            {
+                "id": self.id,
+                "simulation_id": self.simulation_id,
+                "agent_ids": self.agent_ids,
+                "current_agent_index": self.current_agent_index,
+                "status": self.status,
+                "messages": self.messages,
+            }
+        )
         return self.id
-    
+
     @classmethod
     def load(cls, db, conversation_id: str):
         """Load a conversation from the database"""
@@ -41,26 +54,28 @@ class Conversation:
         data = table.get(Query().id == conversation_id)
         if not data:
             return None
-            
+
         conversation = cls(db, data["simulation_id"], data["agent_ids"])
         conversation.id = data["id"]
         conversation.current_agent_index = data["current_agent_index"]
         conversation.status = data["status"]
         conversation.messages = data["messages"]
         return conversation
-    
+
     def get_next_agent_id(self):
         """Get the ID of the agent whose turn it is"""
-        if self.status != "active":
-            return None
+        # if self.status != "active":
+        #     return None
         return self.agent_ids[self.current_agent_index]
-    
+
     def advance_turn(self):
         """Advance to the next agent's turn"""
         self.current_agent_index = (self.current_agent_index + 1) % len(self.agent_ids)
         table = self._db.table("agent_conversations")
-        table.update({"current_agent_index": self.current_agent_index}, Query().id == self.id)
-    
+        table.update(
+            {"current_agent_index": self.current_agent_index}, Query().id == self.id
+        )
+
     def end_conversation(self):
         """Mark the conversation as completed"""
         self.status = "completed"

--- a/models/prompting.py
+++ b/models/prompting.py
@@ -1,0 +1,2 @@
+SYSTEM_MESSAGE = "You are a person living in a world with other people. You want to survive and collaborate with others. To do so, you need to collect resources by forming plans and executing them. To guide your actions, you should use the information about your environment and talk to other people that are around. "
+DESCRIPTION = "These are your personal attributes: Agent ID: {id}, Name: {name}"  # , Personality: {personality}. "

--- a/models/task.py
+++ b/models/task.py
@@ -32,7 +32,7 @@ class Task:
         self.plan_id: str = plan_id  # plan.id
         self.target: str | None = None  # resource.id
         self.payoff: int = 0  # TODO: is this expected or explicit?
-        self.status: TaskStatus = TaskStatus.PENDING
+        # self.status: TaskStatus = TaskStatus.PENDING
         self.worker: str | None = None  # agent.id
 
     def __repr__(self) -> str:
@@ -42,9 +42,10 @@ class Task:
         return {
             "id": self.id,
             "plan_id": self.plan_id,
+            "simulation_id": self.simulation_id,
             "target": self.target,
             "payoff": self.payoff,
-            "status": self.status.value,
+            # "status": self.status.value,
             "worker": self.worker,
         }
 
@@ -63,10 +64,10 @@ class Task:
         table.remove(Query().id == self.id)
         logger.info(f"Deleted task {self.id}")
 
-    def update_status(self, status: TaskStatus):
-        """Update the status of the task."""
-        self.status = status
-        self._save_to_db()
+    # def update_status(self, status: TaskStatus):
+    #     """Update the status of the task."""
+    #     self.status = status
+    #     self._save_to_db()
 
     def assign_agent(self, agent_id: str):
         """Assign an agent to the task."""
@@ -74,6 +75,7 @@ class Task:
         plan = get_plan(self._db, self._nats, self.plan_id, self.simulation_id)
         if agent_id not in plan.get_participants():
             plan.add_participant(agent_id)
+        logger.info(f"Assigning agent {agent_id} to task {self.id}")
         self._save_to_db()
 
     def get_target(self) -> str | None:
@@ -81,13 +83,11 @@ class Task:
         return self.target
 
 
-def get_task(
-    db: DB, nats: Nats, task_id: str, plan_id: str, simulation_id: str
-) -> Task:
+def get_task(db: DB, nats: Nats, task_id: str, simulation_id: str) -> Task:
     task_table = db.table(settings.tinydb.tables.task_table)
     task_data = task_table.get(
         (Query().id == task_id)
-        & (Query().plan_id == plan_id)
+        # & (Query().plan_id == plan_id)
         & (Query().simulation_id == simulation_id)
     )
 
@@ -109,7 +109,7 @@ def get_task(
     )
     task.target = task_data.get("target")
     task.payoff = task_data.get("payoff", 0)
-    task.status = TaskStatus(task_data["status"])
+    # task.status = TaskStatus(task_data["status"])
     task.worker = task_data.get("worker")
 
     return task

--- a/routers/agent.py
+++ b/routers/agent.py
@@ -44,6 +44,44 @@ async def list_agents(simulation_id: str, db: clients.DB):
     return agents
 
 
+@router.post("/{agent_id}/trigger")
+async def trigger_agent(
+    simulation_id: str,
+    agent_id: str,
+    db: clients.DB,
+    nats: Nats,
+    milvus: clients.Milvus,
+):
+    """Trigger an agent to perform a task"""
+    agent = Agent(
+        milvus=milvus, id=agent_id, db=db, simulation_id=simulation_id, nats=nats
+    )
+    agent.load()
+    output = await agent.trigger()
+    return output
+
+
+@router.get("/{agent_id}/context")
+async def get_context(
+    simulation_id: str,
+    agent_id: str,
+    db: clients.DB,
+    nats: Nats,
+    milvus: clients.Milvus,
+):
+    """Get the context of an agent"""
+    agent = Agent(
+        milvus=milvus, db=db, nats=nats, simulation_id=simulation_id, id=agent_id
+    )
+    agent.load()
+    context = agent.get_context()
+    return {
+        "system_message": agent.autogen_agent._system_messages,
+        "description": agent.autogen_agent._description,
+        "context": context,
+    }
+
+
 @router.post("/{agent_id}/chat")
 async def chat_with_agent(
     simulation_id: str,
@@ -53,7 +91,6 @@ async def chat_with_agent(
     milvus: clients.Milvus,
     broker: Nats,
 ):
-
     agent = Agent(
         id=agent_id,
         milvus=milvus,
@@ -69,7 +106,7 @@ async def chat_with_agent(
         subject=f"simulation.{simulation_id}.agent.{agent_id}",
     )
 
-    response = await agent.llm.run(task=msg)
+    response = await agent.autogen_agent.run(task=msg)
 
     content = response.messages[-1].content
     await broker.publish(

--- a/routers/configuration.py
+++ b/routers/configuration.py
@@ -6,10 +6,10 @@ from clients.tinydb import get_client
 
 router = APIRouter(prefix="/configuration", tags=["Configuration"])
 
+
 @router.post("")
 async def save_configuration(
-    config: ConfigurationData,
-    db: TinyDB = Depends(get_client)
+    config: ConfigurationData, db: TinyDB = Depends(get_client)
 ):
     """
     Save or update a configuration based on its name.
@@ -22,13 +22,14 @@ async def save_configuration(
     except Exception as e:
         logger.error(f"Error saving configuration: {e}")
         raise HTTPException(status_code=500, detail="Error saving configuration")
-    return {"message": f"Configuration '{config.name}' saved successfully!", "id": config.id}
+    return {
+        "message": f"Configuration '{config.name}' saved successfully!",
+        "id": config.id,
+    }
+
 
 @router.get("/{name}")
-async def get_configuration(
-    name: str,
-    db: TinyDB = Depends(get_client)
-):
+async def get_configuration(name: str, db: TinyDB = Depends(get_client)):
     """
     Retrieve a specific configuration by its name.
     """
@@ -38,21 +39,18 @@ async def get_configuration(
         raise HTTPException(status_code=404, detail="Configuration not found")
     return config_data
 
+
 @router.get("/")
-async def get_all_configurations(
-    db: TinyDB = Depends(get_client)
-):
+async def get_all_configurations(db: TinyDB = Depends(get_client)):
     """
     Retrieve all configurations.
     """
     table = db.table("configurations")
     return table.all()
 
+
 @router.delete("/{name}")
-async def delete_configuration(
-    name: str,
-    db: TinyDB = Depends(get_client)
-):
+async def delete_configuration(name: str, db: TinyDB = Depends(get_client)):
     """
     Delete a configuration by its name.
     """

--- a/routers/conversation.py
+++ b/routers/conversation.py
@@ -9,11 +9,16 @@ from clients import Nats
 from models.agent import Agent
 from models.conversation import Conversation
 
-router = APIRouter(prefix="/simulation/{simulation_id}/conversation", tags=["Conversation"])
+router = APIRouter(
+    prefix="/simulation/{simulation_id}/conversation", tags=["Conversation"]
+)
+
+
 # Create a model for the request
 class ConversationCreate(BaseModel):
     agent_ids: List[str]
     initial_prompt: str = "Form a plan."
+
 
 @router.post("")
 async def create_conversation(
@@ -21,55 +26,56 @@ async def create_conversation(
     conversation_data: ConversationCreate,
     db: clients.DB,
     milvus: clients.Milvus,
-    broker: Nats
+    broker: Nats,
 ):
     """Create a new conversation between agents"""
     # Verify all agents exist
     table = db.table("agents")
     for agent_id in conversation_data.agent_ids:
-        agent = table.get((Query().id == agent_id) & (Query().simulation_id == simulation_id))
+        agent = table.get(
+            (Query().id == agent_id) & (Query().simulation_id == simulation_id)
+        )
         if not agent:
             raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
-    
+
     # Create the conversation
     conversation = Conversation(
         db=db,
         simulation_id=simulation_id,
         agent_ids=conversation_data.agent_ids,
-        initial_prompt=conversation_data.initial_prompt
+        initial_prompt=conversation_data.initial_prompt,
     )
     conversation_id = conversation.save()
-    
+
     # Notify first agent it's their turn
     first_agent_id = conversation.get_next_agent_id()
     await broker.publish(
-        message=json.dumps({
-            "conversation_id": conversation_id,
-            "type": "conversation_turn"
-        }),
-        subject=f"simulation.{simulation_id}.agent.{first_agent_id}.turn"
+        message=json.dumps(
+            {"conversation_id": conversation_id, "type": "conversation_turn"}
+        ),
+        subject=f"simulation.{simulation_id}.agent.{first_agent_id}.turn",
     )
-    
+
     return {
         "id": conversation_id,
         "simulation_id": simulation_id,
         "agent_ids": conversation_data.agent_ids,
         "status": conversation.status,
-        "current_agent_id": first_agent_id
+        "current_agent_id": first_agent_id,
     }
-    
+
+
 @router.get("/{conversation_id}")
-async def get_conversation(
-    simulation_id: str,
-    conversation_id: str,
-    db: clients.DB
-):
+async def get_conversation(simulation_id: str, conversation_id: str, db: clients.DB):
     """Get conversation details and history"""
     table = db.table("agent_conversations")
-    conversation = table.get((Query().id == conversation_id) & (Query().simulation_id == simulation_id))
+    conversation = table.get(
+        (Query().id == conversation_id) & (Query().simulation_id == simulation_id)
+    )
     if not conversation:
         raise HTTPException(status_code=404, detail="Conversation not found")
     return conversation
+
 
 @router.post("/{conversation_id}/advance")
 async def advance_conversation(
@@ -77,17 +83,17 @@ async def advance_conversation(
     conversation_id: str,
     db: clients.DB,
     milvus: clients.Milvus,
-    broker: Nats
+    broker: Nats,
 ):
     """Process the current agent's turn and advance to the next agent"""
     # Load the conversation
     conversation = Conversation.load(db, conversation_id)
     if not conversation or conversation.simulation_id != simulation_id:
         raise HTTPException(status_code=404, detail="Conversation not found")
-    
+
     if conversation.status != "active":
         return {"status": "completed", "message": "Conversation has ended"}
-    
+
     # Get the current agent
     current_agent_id = conversation.get_next_agent_id()
     agent = Agent(
@@ -95,38 +101,37 @@ async def advance_conversation(
         milvus=milvus,
         db=db,
         simulation_id=simulation_id,
-        nats=broker
+        nats=broker,
     )
     agent.load()
-    
+
     # Process the agent's turn
     content, should_continue = await agent.process_turn(conversation_id)
-    
+
     # Check if we should end the conversation
     if not should_continue:
         conversation.end_conversation()
         return {
             "status": "completed",
             "message": "Agent ended the conversation",
-            "content": content
+            "content": content,
         }
-    
+
     # Advance to the next agent's turn
     conversation.advance_turn()
     next_agent_id = conversation.get_next_agent_id()
-    
+
     # Notify the next agent
     await broker.publish(
-        message=json.dumps({
-            "conversation_id": conversation_id,
-            "type": "conversation_turn"
-        }),
-        subject=f"simulation.{simulation_id}.agent.{next_agent_id}.turn"
+        message=json.dumps(
+            {"conversation_id": conversation_id, "type": "conversation_turn"}
+        ),
+        subject=f"simulation.{simulation_id}.agent.{next_agent_id}.turn",
     )
-    
+
     return {
         "status": "active",
         "current_agent_id": current_agent_id,
         "next_agent_id": next_agent_id,
-        "content": content
+        "content": content,
     }

--- a/routers/plan.py
+++ b/routers/plan.py
@@ -185,23 +185,23 @@ async def remove_task(
     return {"message": "Task removed successfully"}
 
 
-@router.put("/{plan_id}/task/{task_id}/status")
-async def update_task_status(
-    simulation_id: str, plan_id: str, task_id: str, status: str, db: DB, nats: Nats
-):
-    """Update the status of a task"""
-    try:
-        task = get_task(db, nats, task_id, plan_id, simulation_id)
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+# @router.put("/{plan_id}/task/{task_id}/status")
+# async def update_task_status(
+#     simulation_id: str, plan_id: str, task_id: str, status: str, db: DB, nats: Nats
+# ):
+#     """Update the status of a task"""
+#     try:
+#         task = get_task(db, nats, task_id, simulation_id)
+#     except ValueError as e:
+#         raise HTTPException(status_code=404, detail=str(e))
 
-    try:
-        new_status = TaskStatus(status)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid task status")
+#     try:
+#         new_status = TaskStatus(status)
+#     except ValueError:
+#         raise HTTPException(status_code=400, detail="Invalid task status")
 
-    task.update_status(new_status)
-    return {"message": "Task status updated successfully"}
+#     task.update_status(new_status)
+#     return {"message": "Task status updated successfully"}
 
 
 @router.put("/{plan_id}/task/{task_id}/assign")
@@ -210,7 +210,7 @@ async def assign_task(
 ):
     """Assign a task to an agent"""
     try:
-        task = get_task(db, nats, task_id, plan_id, simulation_id)
+        task = get_task(db, nats, task_id, simulation_id)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
 

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,3 @@
+from .plan_tools import make_plan, add_task, take_on_task
+
+available_tools = [make_plan, add_task, take_on_task]

--- a/tools/plan_tools.py
+++ b/tools/plan_tools.py
@@ -1,0 +1,108 @@
+import uuid
+from loguru import logger
+from typing import Annotated
+from models.plan import Plan, get_plan
+from models.task import Task, get_task
+# from fastapi import HTTPException
+
+
+# Use `Annotated` to describe each function parameter for the LLM.
+# The `agent_id` and `simulation_id` arguments are automatically injected by the agent at runtime and never exposed to the LLM.
+# This is done to reduce the amount of information the LLM needs to generate and thereby keep the tool calls simple.
+# Make sure to always include the `agent_id` and `simulation_id` arguments in your function signature even if you don't use them in the function body.
+# If there is need to inject more arguments, we can consider to further refactor the code.
+async def make_plan(
+    goal: Annotated[
+        str,
+        "A concise description of the goal of the plan.",
+    ],
+    # participants: Annotated[
+    #     list[Annotated[str, "The agents that are participating in the plan."]],
+    #     "A list of participants",
+    # ], # Participants will join the plan by separate tool call
+    # tasks: Annotated[
+    #     list[Annotated[str, "A short description of the task"]],
+    #     "A list of tasks that have to be performed to execute the plan.",
+    # ], # Tasks will be added by separate tool call
+    agent_id: str,
+    simulation_id: str,
+):
+    """Form a new plan for resource acquisition."""
+    from clients.tinydb import get_client
+    from clients.nats import nats_broker
+
+    db = get_client()
+    nats = nats_broker()
+
+    plan_id = uuid.uuid4().hex
+
+    try:
+        plan = Plan(db=db, id=plan_id, nats=nats, simulation_id=simulation_id)
+        plan.owner = agent_id
+        plan.participants = []  # participants or []
+        plan.goal = goal
+
+        plan.create()
+    except Exception as e:
+        logger.error(f"Error creating plan: {e}")
+
+
+async def add_task(
+    target: Annotated[str, "The ID of the resource to be acquired by the task."],
+    payoff: Annotated[int, "The expected payoff of the task."],
+    plan_id: Annotated[str, "The ID of the plan to which the task will be added."],
+    agent_id: str,
+    simulation_id: str,
+):
+    """Create a new task for resource collection and add this task to a plan."""
+    from clients.tinydb import get_client
+    from clients.nats import nats_broker
+
+    db = get_client()
+    nats = nats_broker()
+
+    task_id: str = uuid.uuid4().hex
+
+    # TODO: check how error handling effects autogen tool calls
+    # try:
+    #     plan = get_plan(db, nats, plan_id, simulation_id)
+    # except ValueError:
+    #     raise HTTPException(status_code=404, detail="Plan not found")
+
+    # if task_id in plan.get_tasks():
+    #     raise HTTPException(status_code=400, detail="Task already in plan")
+
+    try:
+        task = Task(
+            id=task_id, nats=nats, db=db, plan_id=plan_id, simulation_id=simulation_id
+        )
+        task.target = target
+        task.payoff = payoff
+        task.create()
+    except Exception as e:
+        logger.error(f"Error creating task: {e}")
+
+
+async def take_on_task(
+    task_id: Annotated[str, "The ID of the task to you will work on."],
+    agent_id: str,
+    simulation_id: str,
+):
+    """Take responsibility for a task and join its plan."""
+    from clients.tinydb import get_client
+    from clients.nats import nats_broker
+
+    db = get_client()
+    nats = nats_broker()
+
+    try:
+        task = get_task(db, nats, task_id, simulation_id)
+        plan_id = task.plan_id
+        plan = get_plan(db, nats, plan_id, simulation_id)
+    except ValueError as e:
+        logger.error(f"Error getting task: {e}")
+        return
+        # raise HTTPException(status_code=404, detail=str(e))
+
+    plan.add_participant(agent_id)
+    task.assign_agent(agent_id)


### PR DESCRIPTION
Contributes to https://github.com/epoikos-project/issues/issues/19
This PR adds the main setup for tool calling with autogen which enables our agent to perform actions such as making a plan or interacting with the world.
A new tool in form of a python function should be defined and registered in the tools directory and is then automatically provided to the agent.   
Tools should be kept as simple as possible. This means: only ask the agent for arguments strictly necessary to generate, agent_id and simulation_id will be injected automatically, use default values or automatically generated ids where appropriate. Take a look at the current examples to get an idea how to implement this for other actions.

This PR also adds a first version of the prompt and context that is passed to the llm agent. `context.py` defines some classes used for formatting different artefacts. The agents then uses `_load_context()` and `get_context()` to populate the current context based on its observations and states. Some of this is mocked at the moment.

To test and play around with the agent the /trigger endpoint can be used. 

@esharaheel please think about how your relationship component could provide the `relationship_status` to be used in the `AgentObservation` (https://github.com/epoikos-project/issues/issues/21)
@pgaenz add your tool calls as needed (https://github.com/epoikos-project/issues/issues/27) and think about how we can populate the observations from the world when loading the context (https://github.com/epoikos-project/issues/issues/28)

@ItsZiroy @fengelnsbauer FYI
