### PR TITLE
feat: backup for db files

### DIFF
--- a/models/simulation.py
+++ b/models/simulation.py
@@ -14,6 +14,7 @@ from models.agent import Agent
 from models.simulation_runner import SimulationRunner
 from models.world import World
 import asyncio
+import shutil
 
 
 class Simulation:
@@ -66,6 +67,15 @@ class Simulation:
                 name=f"simulation-{self.id}", subjects=[f"simulation.{self.id}.>"]
             )
         )
+
+    def _backup_file(self, src: str, dst: str) -> None:
+        try:
+            shutil.copy(src, dst)
+            logger.debug(f"Backup from {src} to {dst} successful.")
+        except FileNotFoundError:
+            logger.error(f"Error creating backup: {src} not found.")
+        except Exception as e:
+            logger.error(f"Error creating backup: {e}")
 
     async def delete(self, milvus: MilvusClient):
         logger.info(f"Deleting Simulation {self.id}")
@@ -134,6 +144,9 @@ class Simulation:
 
         This method is called by the SimulationRunner for every tick.
         """
+        # backup db of the current tick
+        self._backup_file("data/tinydb/db.json", "data/tinydb/db_backup_tick-1.json")
+
         self._db.clear_cache()
         self._tick_counter += 1
         logger.debug(f"[SIM {self.id}] Tick {self._tick_counter}")
@@ -174,4 +187,12 @@ class Simulation:
             await agent.trigger()
 
         tasks = [run_agent(row) for row in agent_rows]
+        # backup db once every agent was ticked and keep the last two backups
+        if agent_rows and (self._tick_counter % len(agent_rows) == 0):
+            self._backup_file(
+                "data/tinydb/db_backup_step-1.json", "data/tinydb/db_backup_step-2.json"
+            )
+            self._backup_file(
+                "data/tinydb/db.json", "data/tinydb/db_backup_step-1.json"
+            )
         await asyncio.gather(*tasks)


### PR DESCRIPTION
Creates a copy of the database for the previous tick, as well as the last two "steps" (i.e. after every agent has been ticked once).
As discussed, this is just a simple solution for now to quickly restart the simulation if something breaks or unexpected happens. In the future, we might want to use the replay functionality to make this more flexible.