### PR TITLE
fix: agent movement with directions

### DIFF
--- a/models/agent.py
+++ b/models/agent.py
@@ -140,6 +140,7 @@ class Agent:
             description=DESCRIPTION.format(
                 id=self.id,
                 name=self.name,
+                location=self.get_location(),
                 # personality=self.personality
             ),
             reflect_on_tool_use=False,  # False as our current tools do not return text
@@ -577,6 +578,7 @@ class Agent:
                 description=DESCRIPTION.format(
                     id=self.id,
                     name=self.name,
+                    location=self.get_location(),
                     # personality=self.personality
                 ),
                 reflect_on_tool_use=False,  # False as our current tools do not return text

--- a/models/prompting.py
+++ b/models/prompting.py
@@ -17,7 +17,7 @@ SYSTEM_MESSAGE = (
     "(3) talk and cooperate with other agents to execute more favorable plans and collect more resources. "
     "\nTo guide your actions, you should use the information about your environment and talk to other people that are around."
 )
-DESCRIPTION = "These are your personal attributes: ID: {id}, Name: {name}"  # , Personality: {personality}. "
+DESCRIPTION = "These are your personal attributes: ID: {id}, Name: {name}, Current location: {location}"  # , Personality: {personality}. "
 
 
 class HungerContextPrompt:

--- a/models/world.py
+++ b/models/world.py
@@ -575,7 +575,7 @@ class World:
             if obj is not None:
                 obj_location = (obj["x_coord"], obj["y_coord"])
                 # Move agent one step towards the object
-                agent_location = (agent[0]["x_coord"], agent[0]["y_coord"])
+                agent_location = (agent["x_coord"], agent["y_coord"])
                 dx = obj_location[0] - agent_location[0]
                 dy = obj_location[1] - agent_location[1]
                 step_x = 1 if dx > 0 else -1 if dx < 0 else 0


### PR DESCRIPTION
reworks the movement logic to use directions 'up', 'down', 'left', 'right' instead of coordinates. can also use 'object_id' of resource or agent, however in my first tests agents did not choose to use this. further improving the prompting might help to encourage this